### PR TITLE
Test/report date validation

### DIFF
--- a/infos/forms.py
+++ b/infos/forms.py
@@ -5,6 +5,7 @@ from company.models import Company
 
 from .fields import CompanyModelChoiceField, ReportCategoryModelChoiceField
 from .models import ReportCategory
+import datetime
 
 STRING_COMPANY = "Empresa envolvida:"
 STRING_EMPTY_COMPANY = "Selecione uma empresa"
@@ -15,6 +16,12 @@ STRING_CATEGORY = "Escolha uma categoria de denúncia"
 STRING_EMPTY_CATEGORY = "Selecione uma categoria"
 STRING_DATE = "Data da ocorrência:"
 
+def valid_date(value):
+    if value > datetime.date.today():
+        raise forms.ValidationError("A data não pode ser maior que a data atual!")
+    elif value < datetime.date(1970, 1, 1):
+        raise forms.ValidationError("A data não pode ser menor que 01/01/1970!")
+    return value
 
 class ReportForm(forms.Form):
     template_name = "form/report_form_template.html"
@@ -36,7 +43,7 @@ class ReportForm(forms.Form):
         widget=forms.Textarea(attrs={"cols": "45", "rows": "8"}),
     )
     date = forms.DateField(
-        label=STRING_DATE, widget=widgets.DateInput(attrs={"type": "date"})
+        label=STRING_DATE, widget=widgets.DateInput(attrs={"type": "date"}), validators=[valid_date],
     )
     contact_permission = forms.BooleanField(
         label=STRING_CONTACT, required=False, initial=False

--- a/infos/tests.py
+++ b/infos/tests.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -120,6 +121,65 @@ class ReportTestCase(TestCase):
         self.assertIn(report, user.reports_sent.all())
         print("Teste Infos-Report-7: Denúncia associada ao usuário com sucesso.")
 
+    def test_validation_date_today(self):
+        form = ReportForm(
+            data={
+                "company": self.company,
+                "category": self.category,
+                "link": "https://teste.com",
+                "description": "a",
+                "contact_permission": True,
+                "date": datetime.now(),
+            }
+        )
+        form.is_valid()
+        self.assertDictEqual(form.errors, {})
+        print("Teste Infos-Report-8: Data válida aceita com sucesso.")
+
+    def test_validation_date_after_today(self):
+        form = ReportForm(
+            data={
+                "company": self.company,
+                "category": self.category,
+                "link": "https://teste.com",
+                "description": "a",
+                "contact_permission": True,
+                "date": datetime.now() + timedelta(days=1),
+            }
+        )
+        form.is_valid()
+        self.assertEquals(list(form.errors.keys())[0], "date")
+        print("Teste Infos-Report-9: Data depois do dia atual negada com sucesso.")
+
+    def test_validation_date_1970(self):
+        form = ReportForm(
+            data={
+                "company": self.company,
+                "category": self.category,
+                "link": "https://teste.com",
+                "description": "a",
+                "contact_permission": True,
+                "date": "1970-01-01",
+            }
+        )
+        form.is_valid()
+        self.assertDictEqual(form.errors, {})
+        print("Teste Infos-Report-8: Data válida aceita com sucesso.")
+
+    def test_validation_date_before_1970(self):
+        form = ReportForm(
+            data={
+                "company": self.company,
+                "category": self.category,
+                "link": "https://teste.com",
+                "description": "a",
+                "contact_permission": True,
+                "date": "1969-12-31",
+            }
+        )
+        form.is_valid()
+        self.assertEquals(list(form.errors.keys())[0], "date")
+        print("Teste Infos-Report-9: Data depois do dia atual negada com sucesso.")
 
 class InfoDetailTestCase(TestCase):
     def setUp(self) -> None:

--- a/infos/tests.py
+++ b/infos/tests.py
@@ -134,7 +134,7 @@ class ReportTestCase(TestCase):
         )
         form.is_valid()
         self.assertDictEqual(form.errors, {})
-        print("Teste Infos-Report-8: Data válida aceita com sucesso.")
+        print("Teste Infos-Report-8: Data do dia atual aceita com sucesso.")
 
     def test_validation_date_after_today(self):
         form = ReportForm(
@@ -164,7 +164,7 @@ class ReportTestCase(TestCase):
         )
         form.is_valid()
         self.assertDictEqual(form.errors, {})
-        print("Teste Infos-Report-8: Data válida aceita com sucesso.")
+        print("Teste Infos-Report-10: Data de 1970 aceita com sucesso.")
 
     def test_validation_date_before_1970(self):
         form = ReportForm(
@@ -179,7 +179,7 @@ class ReportTestCase(TestCase):
         )
         form.is_valid()
         self.assertEquals(list(form.errors.keys())[0], "date")
-        print("Teste Infos-Report-9: Data depois do dia atual negada com sucesso.")
+        print("Teste Infos-Report-11: Data antes de 1970 negada com sucesso.")
 
 class InfoDetailTestCase(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Foi adicionada a validação de datas no formulário de denúncias de forma que sigam os limites de datas de 1970 até o dia atual, não permitindo datas futuras e antes de 1970, como descrito na issue #86 